### PR TITLE
Hierarchy 'add all' include empty options too

### DIFF
--- a/src/pages/dataset/actions.js
+++ b/src/pages/dataset/actions.js
@@ -188,6 +188,7 @@ export function requestDimensionsSuccess(datasetId, responseData) {
 
 function parseDimensions(datasetID, dimensionsJSON) {
     let optionsCount;
+    let selectableCount;
     let selectedCount;
 
     if (!(dimensionsJSON instanceof Array)) {
@@ -201,11 +202,13 @@ function parseDimensions(datasetID, dimensionsJSON) {
             dimensions: dimensionsJSON.map(dimension => {
                 optionsCount = 0;
                 selectedCount = 0;
+                selectableCount = 0;
 
                 dimension.options = parseOptions(dimension.options);
                 dimension.datasetID = datasetID;
                 dimension.optionsCount = optionsCount;
                 dimension.selectedCount = selectedCount;
+                dimension.selectableCount = selectableCount;
                 dimension.edited = selectedCount > 0
                 return dimension;
             }),
@@ -215,15 +218,23 @@ function parseDimensions(datasetID, dimensionsJSON) {
     function parseOptions(options, selectedStatus = true) {
         return options.map(option => {
             optionsCount ++;
+            if (!option.empty) {
+                selectableCount ++;
+            }
 
             // todo: we should always use code, requires refactoring across whole app
             if (option.code) {
                 option.id = option.code;
             } else {
-                console.error('Code is missing');
+                console.error('Code value is missing');
             }
 
-            option.selected = option.selected === false ? false : selectedStatus;
+            if (!option.empty) {
+                option.selected = option.selected === false ? false : selectedStatus;
+            } else {
+                option.selected = false;
+            }
+
             selectedCount += option.selected ? 1 : 0;
             if (option.options && option.options.length > 0) {
                 option.options = parseOptions(option.options, selectedStatus);

--- a/src/pages/dimension/components/Dimension.jsx
+++ b/src/pages/dimension/components/Dimension.jsx
@@ -73,7 +73,7 @@ class Dimension extends Component {
         const isReady = props.isReady;
         const isHierarchical = props.isHierarchical;
         const autoDeselected = props.autoDeselected;
-        const allSelected = props.selectedCount === props.optionsCount;
+        const allSelected = props.selectedCount === props.selectableCount;
         const dispatch = props.dispatch;
         const datasetID = props.datasetID;
         const edition = props.params.edition;
@@ -210,7 +210,8 @@ function mapStateToProps(state, ownProps) {
             isHierarchical: dimension.hierarchical || false,
             isFlat: isHierarchyFlat(dimension.options),
             optionsCount: dimension.optionsCount,
-            selectedCount: dimension.selectedCount
+            selectedCount: dimension.selectedCount,
+            selectableCount: dimension.selectableCount
         });
     }
 

--- a/src/pages/dimension/utils.js
+++ b/src/pages/dimension/utils.js
@@ -6,7 +6,7 @@ export function findOptionsByType ({options, type}) {
 
 export function toggleSelectedOptions ({options, selected = true}) {
     return options.map(option => {
-        option.selected = option.empty ? false : selected;
+        option.selected = selected;
         if (option.options && option.options.length > 0) {
             option.options = toggleSelectedOptions({ options: option.options, selected });
         }

--- a/src/pages/dimension/utils.js
+++ b/src/pages/dimension/utils.js
@@ -6,7 +6,7 @@ export function findOptionsByType ({options, type}) {
 
 export function toggleSelectedOptions ({options, selected = true}) {
     return options.map(option => {
-        option.selected = selected;
+        option.selected = option.empty ? false : selected;
         if (option.options && option.options.length > 0) {
             option.options = toggleSelectedOptions({ options: option.options, selected });
         }


### PR DESCRIPTION
### What

On the function that toggles all options it now includes options that are empty. 

Not having this was causing the browser back functionality to behave strangely in the hierarchy add all screens. Because it wasn't selecting all options it was making it appear to the component that it had been selected by the user and we therefore needed to show the summary screen.

### How to review

Run existing tests on the application to make sure it hasn't broken anything else unexpectedly. 

Also the browser back button after clearing all selections takes you back the hierarchy navigation screen.

### Who can review

@girinattu please!
