### PR TITLE
feature/cache-control-max-age

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node {
 
     stage('Bundle') {
         def revision = revisionFrom(readFile('git-tag').trim(), readFile('git-commit').trim())
-        sh "aws s3 cp --acl public-read --recursive dist s3://${env.S3_CDN_BUCKET}/dp-dd-react-app/${revision}/"
+        sh "aws s3 cp --acl public-read --cache-control max-age=1209600 --recursive dist s3://${env.S3_CDN_BUCKET}/dp-dd-react-app/${revision}/"
     }
 }
 


### PR DESCRIPTION
### What

Added cache control max age header. Value is currently set to 2 weeks.

### How to review

Request assets from this build revision, the `Cache-Control: max-age` header should be set to `1209600` (2 weeks).

### Who can review

Anyone but myself.
